### PR TITLE
Fixes issue with reloading based on repository.json url

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Home Assistant Developer Add-ons",
-  "url": "https://developers.home-assistant.io/",
+  "url": "https://github.com/home-assistant/hassio-addons-development",
   "maintainer": "HomeAssistant Team <info@home-assistant.io>"
 }


### PR DESCRIPTION
Eventually, Hass.io uses the URL specified in the repository.json to update the repo...
this obviously fails.

![image](https://user-images.githubusercontent.com/195327/54067780-b138a680-4244-11e9-8070-bd8c913e7af9.png)

(This goes wrong after another repo is being added). This fixes it for current users.